### PR TITLE
リバーシプログラムの修正

### DIFF
--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -47,7 +47,7 @@ module ReversiMethods
 
     # コピーした盤面にて石の配置を試みて、成功すれば反映する
     copied_board = Marshal.load(Marshal.dump(board))
-    copied_board[pos.col][pos.row] = stone_color
+    copied_board[pos.row][pos.col] = stone_color
 
     turn_succeed = false
     Position::DIRECTIONS.each do |direction|

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -63,6 +63,7 @@ module ReversiMethods
   def turn(board, target_pos, attack_stone_color, direction)
     return false if target_pos.out_of_board?
     return false if target_pos.stone_color(board) == attack_stone_color
+    return false if target_pos.stone_color(board) == BLANK_CELL
 
     next_pos = target_pos.next_position(direction)
     if (next_pos.stone_color(board) == attack_stone_color) || turn(board, next_pos, attack_stone_color, direction)

--- a/lib/reversi_methods.rb
+++ b/lib/reversi_methods.rb
@@ -87,6 +87,7 @@ module ReversiMethods
         return true if put_stone(board, position.to_cell_ref, attack_stone_color, dry_run: true)
       end
     end
+    false
   end
 
   def count_stone(board, stone_color)


### PR DESCRIPTION
reversi_methods.rbの以下の箇所を修正して、バグを解決しました。
- put_stoneのコピーの盤面のcolor変更の際、配列の行列が逆になっていたので修正
- turnメソッドで石を置いた全方位を考える際にtarget.posが空白だったときの処理（falseを返す）を追加した
- placeable?メソッド内の行と列のループでtrueが返らなかったとき（盤面に置けないとき）、falseを戻り値として追加